### PR TITLE
css changes + log

### DIFF
--- a/loggar/Axel.md
+++ b/loggar/Axel.md
@@ -19,3 +19,7 @@
 -skapat en widget som ska innehålla meny med produktkategorier
 -lagt in widgeten vid 'woocommerce_before_main_content'-hooken
 -stylat menyn
+-Fick problem med MAMP
+
+5/5
+-MAMP-problemet var att jag hade satt siteurl/home till local istället för localhost i min databas.

--- a/wp-content/themes/slant/css/main.css
+++ b/wp-content/themes/slant/css/main.css
@@ -9,7 +9,6 @@
 main {
     width: 100%;
     height: auto;
-    margin-top: 30px;
 
     display: flex;
     flex-direction: column;

--- a/wp-content/themes/slant/css/shop.css
+++ b/wp-content/themes/slant/css/shop.css
@@ -1,5 +1,6 @@
-li#woocommerce_product_categories-2 {
+#woocommerce_product_categories-2 {
     max-width: unset;
+    margin: 0;
 }
 
 ul.product-categories {


### PR DESCRIPTION
-Added margin: 0 to the 'product categories menu' (#woocommerce_product_categories-2 in shop.css). It had an unwanted margin to the right.
-Removed margin-top in main.css. To get the 'product categories menu' directly under the header
-Updated my log